### PR TITLE
feat: extract configurable NounsAuctionHouse vars into separate contract

### DIFF
--- a/packages/nouns-contracts/contracts/BostonManager.sol
+++ b/packages/nouns-contracts/contracts/BostonManager.sol
@@ -2,16 +2,37 @@
 pragma solidity ^0.8.6;
 
 contract BostonManager {
-    uint public reservePrice;
+    uint256 public reservePrice;
+    uint8 public minBidIncrementPercentage;
+    uint256 public duration;
+    uint256 public timeBuffer;
 
     // Sets reserve price on contract deploy
-    constructor(uint _reservePrice) {
+    constructor(uint256 _reservePrice, uint8 _minBidIncrementPercentage, uint256 _duration, uint256 _timeBuffer) {
         reservePrice = _reservePrice;
+        minBidIncrementPercentage = _minBidIncrementPercentage;
+        duration = _duration;
+        timeBuffer = _timeBuffer;
     }
 
     // Returns reservePrice
-    function getReservePrice() public view returns (uint) {
+    function getReservePrice() public view returns (uint256) {
         return reservePrice;
+    }
+
+    // returns minBidIncrementPercentage
+    function getMinBidIncrementPercentage() public view returns (uint8) {
+        return minBidIncrementPercentage;
+    }
+
+    // Returns duration of auction
+    function getDuration() public view returns (uint256) {
+        return duration;
+    }
+
+    // Returns timeBuffer
+    function getTimeBuffer() public view returns (uint256) {
+        return timeBuffer;
     }
 
     // TODO: set reserve price based on if caller is owner (Boston DAO)

--- a/packages/nouns-contracts/contracts/BostonManager.sol
+++ b/packages/nouns-contracts/contracts/BostonManager.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.8.6;
+
+contract BostonManager {
+    uint public reservePrice;
+
+    // Sets reserve price on contract deploy
+    constructor(uint _reservePrice) {
+        reservePrice = _reservePrice;
+    }
+
+    // Returns reservePrice
+    function getReservePrice() public view returns (uint) {
+        return reservePrice;
+    }
+
+    // TODO: set reserve price based on if caller is owner (Boston DAO)
+}

--- a/packages/nouns-contracts/contracts/BostonManager.sol
+++ b/packages/nouns-contracts/contracts/BostonManager.sol
@@ -14,26 +14,5 @@ contract BostonManager {
         duration = _duration;
         timeBuffer = _timeBuffer;
     }
-
-    // Returns reservePrice
-    function getReservePrice() public view returns (uint256) {
-        return reservePrice;
-    }
-
-    // returns minBidIncrementPercentage
-    function getMinBidIncrementPercentage() public view returns (uint8) {
-        return minBidIncrementPercentage;
-    }
-
-    // Returns duration of auction
-    function getDuration() public view returns (uint256) {
-        return duration;
-    }
-
-    // Returns timeBuffer
-    function getTimeBuffer() public view returns (uint256) {
-        return timeBuffer;
-    }
-
     // TODO: set reserve price based on if caller is owner (Boston DAO)
 }

--- a/packages/nouns-contracts/contracts/NounsAuctionHouse.sol
+++ b/packages/nouns-contracts/contracts/NounsAuctionHouse.sol
@@ -45,16 +45,16 @@ contract NounsAuctionHouse is INounsAuctionHouse, PausableUpgradeable, Reentranc
     address public weth;
 
     // The minimum amount of time left in an auction after a new bid is created
-    uint256 public timeBuffer;
+    uint256 public timeBuffer = bostonManagerAddress.getTimeBuffer();
 
     // The minimum price accepted in an auction
-    uint256 public reservePrice;
+    uint256 public reservePrice = bostonManagerAddress.getReservePrice();
 
     // The minimum percentage difference between the last bid amount and the current bid
-    uint8 public minBidIncrementPercentage;
+    uint8 public minBidIncrementPercentage = bostonManagerAddress.getMinBidIncrementPercentage();
 
     // The duration of a single auction
-    uint256 public duration;
+    uint256 public duration = bostonManagerAddress.getDuration();
 
     // The active auction
     INounsAuctionHouse.Auction public auction;
@@ -176,6 +176,8 @@ contract NounsAuctionHouse is INounsAuctionHouse, PausableUpgradeable, Reentranc
     /**
      * @notice Set the auction reserve price.
      * @dev Only callable by the owner.
+     *
+     * Pretty sure we can remove this
      */
     function setReservePrice(uint256 _reservePrice) external override onlyOwner {
         reservePrice = _reservePrice;

--- a/packages/nouns-contracts/contracts/NounsAuctionHouse.sol
+++ b/packages/nouns-contracts/contracts/NounsAuctionHouse.sol
@@ -45,16 +45,16 @@ contract NounsAuctionHouse is INounsAuctionHouse, PausableUpgradeable, Reentranc
     address public weth;
 
     // The minimum amount of time left in an auction after a new bid is created
-    uint256 public timeBuffer = bostonManagerAddress.getTimeBuffer();
+    uint256 public timeBuffer = bostonManagerAddress.timeBuffer();
 
     // The minimum price accepted in an auction
-    uint256 public reservePrice = bostonManagerAddress.getReservePrice();
+    uint256 public reservePrice = bostonManagerAddress.reservePrice();
 
     // The minimum percentage difference between the last bid amount and the current bid
-    uint8 public minBidIncrementPercentage = bostonManagerAddress.getMinBidIncrementPercentage();
+    uint8 public minBidIncrementPercentage = bostonManagerAddress.minBidIncrementPercentage();
 
     // The duration of a single auction
-    uint256 public duration = bostonManagerAddress.getDuration();
+    uint256 public duration = bostonManagerAddress.duration();
 
     // The active auction
     INounsAuctionHouse.Auction public auction;

--- a/packages/nouns-contracts/contracts/NounsAuctionHouse.sol
+++ b/packages/nouns-contracts/contracts/NounsAuctionHouse.sol
@@ -32,7 +32,12 @@ import { INounsAuctionHouse } from './interfaces/INounsAuctionHouse.sol';
 import { INounsToken } from './interfaces/INounsToken.sol';
 import { IWETH } from './interfaces/IWETH.sol';
 
+import './BostonManager.sol';
+
 contract NounsAuctionHouse is INounsAuctionHouse, PausableUpgradeable, ReentrancyGuardUpgradeable, OwnableUpgradeable {
+    // Boston DAO Manager
+    BostonManager private bostonManagerAddress;
+
     // The Nouns ERC721 token contract
     INounsToken public nouns;
 
@@ -63,9 +68,9 @@ contract NounsAuctionHouse is INounsAuctionHouse, PausableUpgradeable, Reentranc
         INounsToken _nouns,
         address _weth,
         uint256 _timeBuffer,
-        uint256 _reservePrice,
         uint8 _minBidIncrementPercentage,
-        uint256 _duration
+        uint256 _duration,
+        BostonManager _bostonManagerAddress
     ) external initializer {
         __Pausable_init();
         __ReentrancyGuard_init();
@@ -76,9 +81,9 @@ contract NounsAuctionHouse is INounsAuctionHouse, PausableUpgradeable, Reentranc
         nouns = _nouns;
         weth = _weth;
         timeBuffer = _timeBuffer;
-        reservePrice = _reservePrice;
         minBidIncrementPercentage = _minBidIncrementPercentage;
         duration = _duration;
+        bostonManagerAddress = _bostonManagerAddress;
     }
 
     /**


### PR DESCRIPTION
Here's what I have in mind for the configurable contract that extracts variables. Let me know what you think if this is the way we should go about it.

Feat: fetch reserve price and init of BostonManager contract

